### PR TITLE
HF7 @ 36050

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -37,17 +37,19 @@ var (
 		4: big.NewInt(21800), // HF4
 		5: big.NewInt(22800), // HF5 argonated (argon2id)
 		6: big.NewInt(36000), // HF6 divisor increase
+		7: big.NewInt(36050), // eip 155, 158
 	}
 
 	// Testnet now is HF6, avoiding the block #3 (HF3) difficulty bomb
 	TestnetHF = ForkMap{
-		0: big.NewInt(0), //  hf0 had no changes
-		1: big.NewInt(1), // increase min difficulty to the next multiple of 2048
-		2: big.NewInt(2), // use simple difficulty algo (240 seconds)
-		3: big.NewInt(3), // increase min difficulty for anticipation of gpu mining
-		4: big.NewInt(4), // HF4
-		5: big.NewInt(5), // HF5
-		6: big.NewInt(6), // noop in testnet
+		0: big.NewInt(0),  //  hf0 had no changes
+		1: big.NewInt(1),  // increase min difficulty to the next multiple of 2048
+		2: big.NewInt(2),  // use simple difficulty algo (240 seconds)
+		3: big.NewInt(3),  // increase min difficulty for anticipation of gpu mining
+		4: big.NewInt(4),  // HF4
+		5: big.NewInt(5),  // HF5
+		6: big.NewInt(6),  // noop in testnet
+		7: big.NewInt(25), // eip 155, 158
 	}
 )
 var (
@@ -56,15 +58,21 @@ var (
 		ChainId:        big.NewInt(61717561),
 		HomesteadBlock: big.NewInt(0),
 		EIP150Block:    big.NewInt(0),
+		EIP155Block:    AquachainHF[7],
+		EIP158Block:    AquachainHF[7],
+		ByzantiumBlock: AquachainHF[7],
 		Aquahash:       new(AquahashConfig),
 		HF:             AquachainHF,
 	}
 
-	// TestnetChainConfig contains the chain parameters to run a node on the Ropsten test network.
+	// TestnetChainConfig contains the chain parameters to run a node on the Aquachain test network.
 	TestnetChainConfig = &ChainConfig{
 		ChainId:        big.NewInt(3),
 		HomesteadBlock: big.NewInt(0),
 		EIP150Block:    big.NewInt(0),
+		EIP155Block:    TestnetHF[7],
+		EIP158Block:    TestnetHF[7],
+		ByzantiumBlock: TestnetHF[7],
 		Aquahash:       new(AquahashConfig),
 		HF:             TestnetHF,
 	}

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1     // Major version component of the current release
-	VersionMinor = 6     // Minor version component of the current release
-	VersionPatch = 0     // Patch version component of the current release
-	VersionMeta  = "HF6" // Version metadata to append to the version string
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 7          // Minor version component of the current release
+	VersionPatch = 0          // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
Activate EIP155 and EIP158, Byzantine HF

This should have made it into HF6 but now can be tested before merge and next release.

EIP155 replay protection, Chain ID: 61717561

Spurious Dragon, aka State-clearing, EIP 158/161, was released in Nov 2016. Spurious Dragon is aiming for Dapp developers as well as end users for limited categories of applications, and had a number of security enhancements.

With Byzantine HF:
<li>Addition of ‘REVERT’ opcode, which permits error handling without consuming all gas (<a href="https://github.com/ethereum/EIPs/pull/206">EIP 140</a>)</li>
<li>Transaction receipts now include a status field to indicate success or failure <a href="https://github.com/ethereum/EIPs/pull/658">EIP 658</a>)</li>
<li>Elliptic curve addition and scalar multiplication on alt_bn128 (<a href="https://github.com/ethereum/EIPs/pull/213">EIP 196</a>) and pairing checks (<a href="https://github.com/ethereum/EIPs/pull/212">EIP 197</a>), permitting ZK-Snarks and other cryptographic mathemagic™</li>
<li>Support for big integer modular exponentiation (<a href="https://github.com/ethereum/EIPs/pull/198">EIP 198</a>), enabling RSA signature verification and other cryptographic applications</li>
<li>Support for variable length return values (<a href="https://github.com/ethereum/EIPs/pull/211">EIP 211</a>)</li>
<li>Addition of the ‘STATICCALL’ opcode, permitting non-state-changing calls to other contracts (<a href="https://github.com/ethereum/EIPs/pull/214">EIP 214</a>)</li> 